### PR TITLE
Fixes a bug with iterating over the current value

### DIFF
--- a/libs/bart_derive/src/scanner.rs
+++ b/libs/bart_derive/src/scanner.rs
@@ -101,7 +101,7 @@ fn section_opener<'a>(input: &'a str) -> Result<Token<'a>, Error> {
 
     let (input, tail) = if input.ends_with('?') {
         (&input[..input.len()-1], Tail::Conditional)
-    } else if input.ends_with('.') {
+    } else if input.ends_with('.') && input.len() > 1 {
         (&input[..input.len()-1], Tail::Scope)
     } else {
         (input, Tail::None)

--- a/libs/bart_derive/src/scanner.rs
+++ b/libs/bart_derive/src/scanner.rs
@@ -263,6 +263,15 @@ mod tests {
     }
 
     #[test]
+    fn bart_tag_matches_iteration_section_opener_dot() {
+        assert_eq!(
+            Ok(("", Token::SectionOpener(SectionType::Iteration, name(".").unwrap().1))),
+            bart_tag("{{#.}}")
+        );
+    }
+
+
+    #[test]
     fn bart_tag_matches_negative_iteration_section_opener() {
         assert_eq!(
             Ok(("", Token::SectionOpener(SectionType::NegativeIteration, simple_name("ape")))),

--- a/tests/iteration.rs
+++ b/tests/iteration.rs
@@ -62,3 +62,14 @@ fn it_can_iterate_function() {
         Test { a: 1, b: 2, c: 3 }.to_string()
     );
 }
+
+#[test]
+fn it_can_iterate_dot() {
+    #[derive(BartDisplay)]
+    #[template_string="{{#opt}}{{#.}}{{.}}{{/.}}{{/opt}}"]
+    struct Test { opt: Option<Vec<i32>> }
+    assert_eq!(
+        "123",
+        Test { opt: Some(vec![1, 2, 3]) }.to_string()
+    );
+}


### PR DESCRIPTION
I found this bug when working with Enums. It looks like this is all that is needed to fix it, but I only looked at *scanner.rs* so I might have missed something.