### PR TITLE
Use CARGO_MANIFEST_DIR instead of current directory

### DIFF
--- a/libs/bart_derive/src/lib.rs
+++ b/libs/bart_derive/src/lib.rs
@@ -27,7 +27,7 @@ fn find_attr<'a>(attrs: &'a Vec<syn::Attribute>, name: &str) -> Option<&'a str> 
         .find(|&x| x.name() == name)
         .and_then(|ref attr| match &attr.value {
             &syn::MetaItem::NameValue(_, syn::Lit::Str(ref template, _)) => Some(template),
-            _ => None,
+            _ => None
         })
         .map(|x| x.as_ref())
 }

--- a/libs/bart_derive/src/lib.rs
+++ b/libs/bart_derive/src/lib.rs
@@ -33,11 +33,9 @@ fn find_attr<'a>(attrs: &'a Vec<syn::Attribute>, name: &str) -> Option<&'a str> 
 }
 
 fn buf_file(filename: &PathBuf) -> String {
-    let mut f =
-        File::open(filename).expect(&format!("Unable to open file for reading: {:?}", filename));
+    let mut f = File::open(filename).expect("Unable to open file for reading");
     let mut buf = String::new();
-    f.read_to_string(&mut buf)
-        .expect(&format!("Unable to read file: {:?}", filename));
+    f.read_to_string(&mut buf).expect("Unable to read file");
 
     buf
 }

--- a/libs/bart_derive/src/lib.rs
+++ b/libs/bart_derive/src/lib.rs
@@ -35,7 +35,8 @@ fn find_attr<'a>(attrs: &'a Vec<syn::Attribute>, name: &str) -> Option<&'a str> 
 fn buf_file(filename: &PathBuf) -> String {
     let mut f = File::open(filename).expect("Unable to open file for reading");
     let mut buf = String::new();
-    f.read_to_string(&mut buf).expect("Unable to read file");
+    f.read_to_string(&mut buf)
+        .expect("Unable to read file");
 
     buf
 }

--- a/libs/bart_derive/src/lib.rs
+++ b/libs/bart_derive/src/lib.rs
@@ -33,7 +33,8 @@ fn find_attr<'a>(attrs: &'a Vec<syn::Attribute>, name: &str) -> Option<&'a str> 
 }
 
 fn buf_file<P: AsRef<Path>>(filename: P) -> String {
-    let mut f = File::open(filename).expect("Unable to open file for reading");
+    let mut f = File::open(filename)
+        .expect("Unable to open file for reading");
     let mut buf = String::new();
     f.read_to_string(&mut buf)
         .expect("Unable to read file");

--- a/libs/bart_derive/src/lib.rs
+++ b/libs/bart_derive/src/lib.rs
@@ -14,7 +14,7 @@ use ast::Ast;
 use proc_macro::TokenStream;
 use std::fs::File;
 use std::io::prelude::*;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn user_crate_root() -> PathBuf {
     std::env::var("CARGO_MANIFEST_DIR")
@@ -27,12 +27,12 @@ fn find_attr<'a>(attrs: &'a Vec<syn::Attribute>, name: &str) -> Option<&'a str> 
         .find(|&x| x.name() == name)
         .and_then(|ref attr| match &attr.value {
             &syn::MetaItem::NameValue(_, syn::Lit::Str(ref template, _)) => Some(template),
-            _ => None
+            _ => None,
         })
         .map(|x| x.as_ref())
 }
 
-fn buf_file(filename: &PathBuf) -> String {
+fn buf_file<P: AsRef<Path>>(filename: P) -> String {
     let mut f = File::open(filename).expect("Unable to open file for reading");
     let mut buf = String::new();
     f.read_to_string(&mut buf)


### PR DESCRIPTION
If you use `bart` in a cargo workspace, you are in trouble.
This is because `bart` doesn't respect `CARGO_MANIFEST_DIR`.
In a cargo workspace, the current directory varies depending on the command you run, such as `cargo build` or `cargo test`.