### PR TITLE
Update syn and update to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 name = "bart"
 repository = "https://github.com/maghoff/bart"
 version = "0.1.4"
+edition = "2021"
 readme = "README.md"
 
 [badges]

--- a/libs/bart_derive/Cargo.toml
+++ b/libs/bart_derive/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.5"
 
 [dependencies]
 quote = "0.3.10"
-syn = "0.10.5"
+syn = "0.11.1"
 itertools = "0.6.0"
 
 [dependencies.num]

--- a/libs/bart_derive/Cargo.toml
+++ b/libs/bart_derive/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 name = "bart_derive"
 repository = "https://github.com/maghoff/bart"
 version = "0.1.5"
+edition = "2021"
 
 [dependencies]
 quote = "0.3.10"

--- a/libs/bart_derive/src/ast.rs
+++ b/libs/bart_derive/src/ast.rs
@@ -1,4 +1,4 @@
-use token;
+use crate::token;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Ast<'a> {

--- a/libs/bart_derive/src/generator.rs
+++ b/libs/bart_derive/src/generator.rs
@@ -1,7 +1,7 @@
-use ast;
+use crate::ast;
 use itertools;
 use syn;
-use token;
+use crate::token;
 use quote;
 
 pub trait PartialsResolver {
@@ -120,7 +120,7 @@ pub fn generate(node: ast::Ast, scope_level: u32, partials_resolver: &mut dyn Pa
 mod tests {
     use super::*;
     use token::simple_name;
-    use scanner::name;
+    use crate::scanner::name;
 
     #[test]
     fn resolves_top_level_names() {

--- a/libs/bart_derive/src/generator.rs
+++ b/libs/bart_derive/src/generator.rs
@@ -17,7 +17,7 @@ fn resolve(name: &token::Name, scope_depth: u32) -> syn::Ident {
             let level = scope_depth
                 .checked_sub(x)
                 .unwrap_or_else(|| {
-                    panic!(format!("Too many leading dots ({}) in scope depth of only {}", x, scope_depth));
+                    panic!("Too many leading dots ({}) in scope depth of only {}", x, scope_depth);
                 });
             format!("_s{}", level)
         },
@@ -32,7 +32,7 @@ fn resolve(name: &token::Name, scope_depth: u32) -> syn::Ident {
     syn::Ident::new(full_name)
 }
 
-fn scope(name: token::Name, scope_level: u32, ast: ast::Ast, partials_resolver: &mut PartialsResolver)
+fn scope(name: token::Name, scope_level: u32, ast: ast::Ast, partials_resolver: &mut dyn PartialsResolver)
     -> (syn::Ident, syn::Ident, quote::Tokens)
 {
     let name = resolve(&name, scope_level);
@@ -42,7 +42,7 @@ fn scope(name: token::Name, scope_level: u32, ast: ast::Ast, partials_resolver: 
     (name, scope_variable, nested_generated)
 }
 
-pub fn generate(node: ast::Ast, scope_level: u32, partials_resolver: &mut PartialsResolver) -> quote::Tokens {
+pub fn generate(node: ast::Ast, scope_level: u32, partials_resolver: &mut dyn PartialsResolver) -> quote::Tokens {
     use ast::Ast::*;
     match node {
         Sequence(seq) => {

--- a/libs/bart_derive/src/lib.rs
+++ b/libs/bart_derive/src/lib.rs
@@ -90,7 +90,7 @@ pub fn bart_display(input: TokenStream) -> TokenStream {
     let mut dependencies = Vec::<String>::new();
 
     let generated = {
-        let (template, mut partials_resolver): (_, Box<generator::PartialsResolver>) =
+        let (template, mut partials_resolver): (_, Box<dyn generator::PartialsResolver>) =
             match find_attr(&ast.attrs, "template") {
                 Some(filename) => {
                     let abs_filename = user_crate_root().join(filename);

--- a/libs/bart_derive/src/parser.rs
+++ b/libs/bart_derive/src/parser.rs
@@ -1,6 +1,6 @@
-use ast::Ast;
+use crate::ast::Ast;
 use std::iter::*;
-use token::*;
+use crate::token::*;
 
 #[derive(Debug)]
 pub enum Error<'a> {

--- a/libs/bart_derive/src/scanner.rs
+++ b/libs/bart_derive/src/scanner.rs
@@ -46,10 +46,10 @@ pub fn name<'a>(input: &'a str) -> Result<(&'a str, Name<'a>), Error> {
     let input = input.trim();
 
     let leading_dots = input.find(not_dot).unwrap_or(input.len());
-    let input = input[leading_dots..].trim_left();
+    let input = input[leading_dots..].trim_start();
 
     let (function_call, input) = match input.ends_with("()") {
-        true => (true, input[..input.len() - 2].trim_right()),
+        true => (true, input[..input.len() - 2].trim_end()),
         false => (false, input),
     };
 

--- a/libs/bart_derive/src/scanner.rs
+++ b/libs/bart_derive/src/scanner.rs
@@ -87,8 +87,8 @@ fn unescaped_interpolation<'a>(input: &'a str) -> Result<Token<'a>, Error> {
 }
 
 fn section_opener<'a>(input: &'a str) -> Result<Token<'a>, Error> {
-    enum Head { Positive, Negative };
-    enum Tail { Conditional, Scope, None };
+    enum Head { Positive, Negative }
+    enum Tail { Conditional, Scope, None }
 
     let input = input.trim();
 

--- a/libs/bart_derive/src/scanner.rs
+++ b/libs/bart_derive/src/scanner.rs
@@ -1,7 +1,7 @@
 extern crate num;
 extern crate syn;
 
-use token::*;
+use crate::token::*;
 
 const TAG_OPENER: &'static str = "{{";
 const TAG_CLOSER: &'static str = "}}";

--- a/src/display_html_safe.rs
+++ b/src/display_html_safe.rs
@@ -2,11 +2,11 @@ use nom::*;
 use std::fmt::{self, Display, Write};
 
 struct EscapingWriter<'a> {
-    inner: &'a mut Write
+    inner: &'a mut dyn Write
 }
 
 impl<'a> EscapingWriter<'a> {
-    fn new(inner: &'a mut Write) -> EscapingWriter<'a> {
+    fn new(inner: &'a mut dyn Write) -> EscapingWriter<'a> {
         EscapingWriter { inner: inner }
     }
 }
@@ -34,7 +34,7 @@ impl<'a> Write for EscapingWriter<'a> {
 }
 
 pub trait DisplayHtmlSafe {
-    fn safe_fmt(&self, &mut fmt::Formatter) -> fmt::Result;
+    fn safe_fmt(&self, _: &mut fmt::Formatter) -> fmt::Result;
 }
 
 impl<T: Display> DisplayHtmlSafe for T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ templates.
 
 #![cfg_attr(feature = "specialization", feature(specialization))]
 
-#[macro_use] extern crate nom;
+extern crate nom;
 
 mod display_html_safe;
 


### PR DESCRIPTION
I updated Syn, and I made some changes updating the code for new compiler versions. I ran the tests, and they still passed.

The most important change is updating Syn to 0.11 because 0.10.5 is yanked. I tried to use Bart in a new project, and Cargo kept telling me resolution failed without telling me why. It took me a while to figure out that the reason is that Syn 0.10.5 has been yanked. AFAIK, it makes it impossible to use Bart from crates.io in a new project, unless I could figure out how to manually edit Cargo.lock.

Could you release a new version with the Syn update?

Thanks for making Bart!