### PR TITLE
Fix many warnings with newer Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 travis-ci = { repository = "maghoff/bart", branch = "master" }
 
 [dependencies]
-nom = "2.0.1"
+nom = "8.0.0"
 
 [dev-dependencies]
 

--- a/libs/bart_derive/src/lib.rs
+++ b/libs/bart_derive/src/lib.rs
@@ -125,11 +125,9 @@ pub fn bart_display(input: TokenStream) -> TokenStream {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
 
-    let dummy_const = syn::Ident::new(format!("_IMPL_BART_DISPLAY_FOR_{}", &name));
-
     let gen = quote! {
         #[allow(non_upper_case_globals, unused_attributes, unused_qualifications, unknown_lints, clippy)]
-        const #dummy_const: () = {
+        const _: () = {
             extern crate bart as _bart;
 
             #[automatically_derived]

--- a/libs/bart_derive/src/lib.rs
+++ b/libs/bart_derive/src/lib.rs
@@ -36,7 +36,7 @@ fn buf_file<P: AsRef<Path>>(filename: P) -> String {
     buf
 }
 
-fn parse_str(input: &str) -> Result<Ast, parser::Error> {
+fn parse_str(input: &str) -> Result<Ast<'_>, parser::Error<'_>> {
     parser::parse(scanner::sequence(input).unwrap())
 }
 
@@ -56,7 +56,7 @@ impl<'a> FilesystemPartialsResolver<'a> {
     fn new<T: Into<PathBuf>>(
         base_dir: T,
         dependencies: &mut Vec<String>,
-    ) -> FilesystemPartialsResolver {
+    ) -> FilesystemPartialsResolver<'_> {
         FilesystemPartialsResolver {
             base_dir: base_dir.into(),
             dependencies,

--- a/libs/bart_derive/src/parser.rs
+++ b/libs/bart_derive/src/parser.rs
@@ -3,6 +3,7 @@ use crate::token::*;
 use std::iter::*;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum Error<'a> {
     Mismatch {
         expected: &'static str,


### PR DESCRIPTION
All these changes are just to fix warnings with the current Rust version. For many of them, I read comments that the warnings may be changed to hard errors in the future, so I wanted to fix them before then. All the tests pass, although I haven't done other testing.

The warning with nom v2 was it used an extra semicolon after an expression macro. It was a pain upgrading it because I've never used nom before, but I figured out how to get the new version working and explained the reason for the changes in the commit. I guess it only took me about an hour.

I suppose the most subjective change was `#[allow(dead_code)]` for the error because the fields are only used in the Debug impl, but I figured it was fine.

Let me know what you think. Thanks